### PR TITLE
Remove unwrap() in GTK frontend w/ new error view

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,8 +2,8 @@
 
 extern crate clap;
 extern crate libc;
-extern crate popsicle;
 extern crate pbr;
+extern crate popsicle;
 
 use clap::{App, Arg};
 use pbr::{MultiBar, ProgressBar, Units};

--- a/gtk/src/image.rs
+++ b/gtk/src/image.rs
@@ -8,7 +8,10 @@ use std::sync::mpsc::Receiver;
 pub fn image_load_event_loop(path_receiver: Receiver<PathBuf>, buffer: &BufferingData) {
     while let Ok(path) = path_receiver.recv() {
         buffer.state.store(0b1, Ordering::SeqCst);
-        let (ref mut name, ref mut data) = *buffer.data.lock().unwrap();
+        let (ref mut name, ref mut data) = *buffer
+            .data
+            .lock()
+            .expect("failed to unlock image buffer mutex");
         match load_image(&path, data) {
             Ok(_) => {
                 *name = path;

--- a/gtk/src/main.rs
+++ b/gtk/src/main.rs
@@ -2,8 +2,8 @@ extern crate digest;
 extern crate gdk;
 extern crate gtk;
 extern crate md5;
-extern crate popsicle;
 extern crate pango;
+extern crate popsicle;
 extern crate pwd;
 extern crate sha3;
 

--- a/gtk/src/ui/content/error.rs
+++ b/gtk/src/ui/content/error.rs
@@ -1,0 +1,43 @@
+use gtk::*;
+
+pub struct ErrorView {
+    pub container: Box,
+    pub buffer:    TextBuffer,
+}
+
+impl ErrorView {
+    pub fn new() -> ErrorView {
+        let image = Image::new_from_icon_name("dialog-error", 6);
+        image.set_valign(Align::Start);
+
+        let topic = Label::new("Critical Error Occurred");
+        topic.set_halign(Align::Start);
+        topic.get_style_context().map(|c| c.add_class("h2"));
+
+        let description = TextView::new();
+        description.set_halign(Align::Start);
+        description.get_style_context().map(|c| c.add_class("desc"));
+
+        let left_panel = Box::new(Orientation::Vertical, 0);
+        left_panel
+            .get_style_context()
+            .map(|c| c.add_class("left-panel"));
+        left_panel.pack_start(&image, false, false, 0);
+
+        let right_panel = Box::new(Orientation::Vertical, 0);
+        right_panel
+            .get_style_context()
+            .map(|c| c.add_class("right-panel"));
+        right_panel.pack_start(&topic, false, false, 0);
+        right_panel.pack_start(&description, true, true, 0);
+
+        let container = Box::new(Orientation::Horizontal, 0);
+        container.pack_start(&left_panel, false, false, 0);
+        container.pack_start(&right_panel, true, true, 0);
+
+        ErrorView {
+            container,
+            buffer: description.get_buffer().unwrap(),
+        }
+    }
+}

--- a/gtk/src/ui/content/mod.rs
+++ b/gtk/src/ui/content/mod.rs
@@ -1,9 +1,11 @@
 mod devices;
+mod error;
 mod flashing;
 mod images;
 mod summary;
 
 pub use self::devices::DevicesView;
+pub use self::error::ErrorView;
 pub use self::flashing::FlashView;
 pub use self::images::ImageView;
 pub use self::summary::SummaryView;
@@ -14,6 +16,7 @@ pub struct Content {
     pub container:    Stack,
     pub image_view:   ImageView,
     pub devices_view: DevicesView,
+    pub error_view:   ErrorView,
     pub flash_view:   FlashView,
     pub summary_view: SummaryView,
 }
@@ -26,11 +29,13 @@ impl Content {
         let devices_view = DevicesView::new();
         let flash_view = FlashView::new();
         let summary_view = SummaryView::new();
+        let error_view = ErrorView::new();
 
         container.add_named(&image_view.container, "image");
         container.add_named(&devices_view.container, "devices");
         container.add_named(&flash_view.container, "flash");
         container.add_named(&summary_view.container, "summary");
+        container.add_named(&error_view.container, "error");
         container.set_visible_child_name("image");
 
         Content {
@@ -39,6 +44,7 @@ impl Content {
             devices_view,
             flash_view,
             summary_view,
+            error_view,
         }
     }
 }


### PR DESCRIPTION
All usages of `unwrap` have been replaced within the GTK front end, and these critical error messages will be displayed on a new error view.

Closes #17

![screenshot from 2018-03-22 16-17-20](https://user-images.githubusercontent.com/4143535/37796057-a53e624c-2dec-11e8-8de2-f34d0d8e9321.png)
