### PR TITLE
[GTK] thread::yield_now() -> thread::sleep()

### DIFF
--- a/gtk/src/app/state.rs
+++ b/gtk/src/app/state.rs
@@ -12,7 +12,7 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use gtk;
 use gtk::*;
@@ -171,7 +171,7 @@ impl Connect for App {
                         let hash = state.hash.clone();
                         thread::spawn(move || {
                             while hash.is_busy() {
-                                thread::yield_now();
+                                thread::sleep(Duration::from_millis(16));
                             }
 
                             hash.request(hash_kind);
@@ -179,7 +179,7 @@ impl Connect for App {
 
                         let hash = state.hash.clone();
                         let hash_label = hash_label.clone();
-                        gtk::timeout_add(1000, move || {
+                        gtk::timeout_add(16, move || {
                             if !hash.is_ready() {
                                 return Continue(true);
                             }

--- a/gtk/src/hash.rs
+++ b/gtk/src/hash.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
+use std::time::Duration;
 
 pub(crate) const SLEEPING: usize = 0;
 pub(crate) const PROCESSING: usize = 1;
@@ -74,7 +75,7 @@ pub(crate) fn event_loop(buffer: &BufferingData, hash: &HashState) {
             hash.state.store(PROCESSING, Ordering::SeqCst);
             let mut hash_data = hash.data.lock().unwrap();
             while buffer.state.load(Ordering::SeqCst) != image::COMPLETED {
-                thread::yield_now();
+                thread::sleep(Duration::from_millis(16));
             }
 
             let buffer_data = buffer.data.lock().unwrap();
@@ -104,7 +105,7 @@ pub(crate) fn event_loop(buffer: &BufferingData, hash: &HashState) {
 
             hash.state.store(COMPLETED, Ordering::SeqCst);
         }
-        thread::yield_now();
+        thread::sleep(Duration::from_millis(16));
     }
 }
 


### PR DESCRIPTION
Save CPU cycles by idling for a handful of milliseconds instead of yielding immediately.

Closes #33 