### PR TITLE
Wayland Support

### DIFF
--- a/gtk/src/flash.rs
+++ b/gtk/src/flash.rs
@@ -1,0 +1,57 @@
+use std::fs::File;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use popsicle::{self, DiskError};
+
+pub struct FlashRequest {
+    disk: File,
+    disk_path: String,
+    image_len: u64,
+    image_data: Arc<Vec<u8>>,
+    progress: Arc<AtomicUsize>,
+    finished: Arc<AtomicUsize>,
+}
+
+impl FlashRequest {
+    pub fn new(
+        disk: File,
+        disk_path: String,
+        image_len: u64,
+        image_data: Arc<Vec<u8>>,
+        progress: Arc<AtomicUsize>,
+        finished: Arc<AtomicUsize>,
+    ) -> FlashRequest {
+        FlashRequest {
+            disk,
+            disk_path,
+            image_len,
+            image_data,
+            progress,
+            finished,
+        }
+    }
+
+    pub fn write(self) -> Result<(), DiskError> {
+        let disk = self.disk;
+        let disk_path = self.disk_path;
+        let progress = self.progress;
+        let image_len = self.image_len;
+        let image_data = self.image_data;
+
+        let result = popsicle::write_to_disk(
+            |_msg| (),
+            || (),
+            |value| progress.store(value as usize, Ordering::SeqCst),
+            disk,
+            disk_path,
+            image_len,
+            &image_data,
+            false,
+        );
+
+        self.finished.store(1, Ordering::SeqCst);
+
+        result
+    }
+}

--- a/gtk/src/main.rs
+++ b/gtk/src/main.rs
@@ -1,6 +1,7 @@
 extern crate digest;
 extern crate gdk;
 extern crate gtk;
+extern crate libc;
 extern crate md5;
 extern crate pango;
 extern crate popsicle;
@@ -9,6 +10,7 @@ extern crate sha2;
 
 mod app;
 mod block;
+mod flash;
 mod hash;
 mod image;
 
@@ -17,21 +19,43 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::mpsc::channel;
 use std::thread;
+use std::fs::File;
+use std::sync::mpsc::{Sender, Receiver};
+use std::thread::JoinHandle;
 
 pub use block::BlockDevice;
+pub use flash::FlashRequest;
+
+use popsicle::{DiskError, Mount};
 
 fn main() {
-    // If running in pkexec, restore home directory for open dialog
-    if let Ok(pkexec_uid) = env::var("PKEXEC_UID") {
+    let (devices_request, devices_request_receiver) =
+        channel::<(Vec<String>, Vec<Mount>)>();
+    let (devices_response_sender, devices_response) =
+        channel::<Result<Vec<(String, File)>, DiskError>>();
+    let (flash_request, flash_request_receiver) = channel::<FlashRequest>();
+    let (flash_response_sender, flash_response) = channel();
+
+    authenticated_threads(
+        devices_request_receiver,
+        devices_response_sender,
+        flash_request_receiver,
+        flash_response_sender
+    );
+
+    // If running in pkexec or sudo, restore home directory for open dialog,
+    // and then downgrade permissions back to a regular user.
+    if let Ok(pkexec_uid) = env::var("PKEXEC_UID").or(env::var("SUDO_UID")) {
         if let Ok(uid) = pkexec_uid.parse::<u32>() {
             if let Some(passwd) = pwd::Passwd::from_uid(uid) {
                 env::set_var("HOME", passwd.dir);
+                downgrade_permissions(passwd.uid, passwd.gid);
             }
         }
     }
 
     let (sender, receiver) = channel::<PathBuf>();
-    let app = App::new(sender);
+    let app = App::new(sender, devices_request, devices_response, flash_request, flash_response);
 
     {
         let buffer = app.state.buffer.clone();
@@ -47,4 +71,38 @@ fn main() {
     }
 
     app.connect_events().then_execute()
+}
+
+/// Actions which require root authentication will be spawned as background threads from here.
+///
+/// This function should be called before `downgrade_permissions()`.
+fn authenticated_threads(
+    devices_request: Receiver<(Vec<String>, Vec<Mount>)>,
+    devices_response: Sender<Result<Vec<(String, File)>, DiskError>>,
+    flash_request: Receiver<FlashRequest>,
+    flash_response: Sender<JoinHandle<Result<(), DiskError>>>
+) {
+    thread::spawn(move || {
+        while let Ok((devs, mounts)) = devices_request.recv() {
+            let resp = popsicle::disks_from_args(devs.into_iter(), &mounts, true);
+            let _ = devices_response.send(resp);
+        }
+    });
+
+    thread::spawn(move || {
+        while let Ok(flash_request) = flash_request.recv() {
+            let handle = thread::spawn(move || flash_request.write());
+            let _ = flash_response.send(handle);
+        }
+    });
+}
+
+/// Downgrades the permissions of the current thread to the specified user and group ID.
+fn downgrade_permissions(uid: u32, gid: u32) {
+    unsafe {
+        // By using system calls directly, we apply this on a per-thread basis.
+        // The setresuid() and setresguid() functions apply to all threads.
+        libc::syscall(libc::SYS_setresgid, gid, gid, gid);
+        libc::syscall(libc::SYS_setresuid, uid, uid, uid);
+    }
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Error, ErrorKind, Result};
 use std::os::unix::ffi::OsStringExt;
 
+#[derive(Clone)]
 pub struct Mount {
     pub source:  OsString,
     pub dest:    OsString,


### PR DESCRIPTION
- Background threads will be created which will run authenticated tasks.
- The main thread will use Linux syscalls to downgrade permissions.
- A channel will be used to request information from the authenticated threads.

This _may_ fix the issue of launching Popsicle on a Wayland session. The main thread will initially spawn as root via pkexec or sudo, and will spawn background threads that will remain as root to perform authenticated tasks in the background. After spawning the background threads, permissions are downgraded back to a normal user before initializing GTK, and the UI will run entirely as a normal user.

Fixes #16 