### PR TITLE
Allow prefixes other than /usr/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-prefix ?= /usr/local
+default_prefix = /usr/local
+prefix ?= $(default_prefix)
 exec_prefix = $(prefix)
 bindir = $(exec_prefix)/bin
 libdir = $(exec_prefix)/lib
@@ -24,6 +25,9 @@ ICONS=\
 	24x24@2x/apps/$(BIN).png \
 	512x512@2x/apps/$(BIN).png
 
+BEFORE := $(shell echo $(default_prefix) | sed 's/\//\\\//g')
+AFTER := $(shell echo $(prefix) | sed 's/\//\\\//g')
+
 all: cli gtk
 
 cli: target/release/$(BIN) target/release/$(BIN).1.gz
@@ -48,6 +52,11 @@ install-gtk: gtk
 	for icon in $(ICONS); do \
 		install -D -m 0644 "gtk/assets/icons/$$icon" "$(DESTDIR)$(datadir)/icons/hicolor/$$icon"; \
 	done
+
+	# Fix paths in assets
+	sed -i -e 's/$(BEFORE)/$(AFTER)/g' $(DESTDIR)$(datadir)/applications/popsicle.desktop \
+		&& sed -i -e 's/$(BEFORE)/$(AFTER)/g' $(DESTDIR)$(datadir)/polkit-1/actions/$(POLICY) \
+		&& sed -i -e 's/$(BEFORE)/$(AFTER)/g' $(DESTDIR)$(bindir)/$(PKEXEC_BIN)
 
 install: all install-cli install-gtk
 

--- a/gtk/assets/com.system76.pkexec.popsicle.policy
+++ b/gtk/assets/com.system76.pkexec.popsicle.policy
@@ -12,7 +12,7 @@
       <allow_inactive>auth_admin</allow_inactive>
       <allow_active>auth_admin</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/popsicle-gtk</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/local/bin/popsicle-gtk</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 

--- a/gtk/assets/popsicle-pkexec
+++ b/gtk/assets/popsicle-pkexec
@@ -1,2 +1,2 @@
 #!/bin/sh
-pkexec /usr/bin/popsicle-gtk $@
+pkexec /usr/local/bin/popsicle-gtk $@

--- a/gtk/assets/popsicle.desktop
+++ b/gtk/assets/popsicle.desktop
@@ -9,4 +9,4 @@ Keywords=USB;Flash;Drive;Popsicle;
 MimeType=application/x-cd-image;application/x-raw-disk-image;application/x-raw-disk-image-xz-compressed;
 Terminal=false
 StartupNotify=true
-Exec=/usr/bin/popsicle-pkexec %U
+Exec=/usr/local/bin/popsicle-pkexec %U


### PR DESCRIPTION
Closes #45 

By default, the assets will have a pre-defined path of `/usr/local`, which the make file will correct to whatever `prefix` was defined by the user when running `make install`. This shouldn't affect existing packaging, but should allow installs direct from the source to use whatever prefix they want.