### PR TITLE
Make the timeout for block size detection configurable

### DIFF
--- a/gtk/src/app/state/device_selection.rs
+++ b/gtk/src/app/state/device_selection.rs
@@ -65,7 +65,7 @@ pub fn initialize(
         eprintln!("popsicle: unable to get devices: {}", why);
     }
 
-    refresh_device_list(state, &devices, all, back, error, list, next, stack);
+    refresh_device_list(state, &devices, all, back, error, list, next, stack, 0);
 }
 
 pub fn refresh_device_list(
@@ -77,6 +77,7 @@ pub fn refresh_device_list(
     list: &gtk::ListBox,
     next: &gtk::Button,
     stack: &gtk::Stack,
+    timeout: u64,
 ) {
     let device_list = &state.devices;
     let mut device_list = try_or_error!(
@@ -108,7 +109,7 @@ pub fn refresh_device_list(
             ()
         );
 
-        let button = if let Some(block) = BlockDevice::new(&name) {
+        let button = if let Some(block) = BlockDevice::new(&name, timeout) {
             let too_small = block.sectors() < image_sectors;
 
             let button = CheckButton::new_with_label(&{

--- a/gtk/src/app/state/flash_devices.rs
+++ b/gtk/src/app/state/flash_devices.rs
@@ -188,7 +188,7 @@ pub fn flash_devices(
                 format!("unable to get canonical path of {}", disk_path),
                 ()
             );
-            if let Some(block) = BlockDevice::new(&disk_path) {
+            if let Some(block) = BlockDevice::new(&disk_path, 0) {
                 gtk::Label::new(
                     [&block.label(), " (", &disk_path.to_string_lossy(), ")"]
                         .concat()

--- a/gtk/src/app/state/mod.rs
+++ b/gtk/src/app/state/mod.rs
@@ -252,7 +252,7 @@ impl Connect for App {
                 if state.view.get() == 1 {
                     match device_selection::device_requires_refresh(&state, &back, &error, &next, &stack) {
                         Some(devices) => {
-                            device_selection::refresh_device_list(&state, &devices, &all, &back, &error, &list, &next, &stack);
+                            device_selection::refresh_device_list(&state, &devices, &all, &back, &error, &list, &next, &stack, 5_000);
                             all.set_active(false);
                             next.set_sensitive(false);
                         }

--- a/gtk/src/block.rs
+++ b/gtk/src/block.rs
@@ -6,7 +6,6 @@ use std::thread::sleep;
 use std::time::Duration;
 
 const SLEEP_AFTER_FAIL: u64 = 500;
-const ATTEMPTS: u64 = 10_000 / SLEEP_AFTER_FAIL;
 
 fn read_file(path: &Path) -> String {
     File::open(path)
@@ -20,14 +19,15 @@ fn read_file(path: &Path) -> String {
 
 pub struct BlockDevice {
     path: PathBuf,
+    timeout: u64
 }
 
 impl BlockDevice {
-    pub fn new(path: &Path) -> Option<BlockDevice> {
+    pub fn new(path: &Path, timeout: u64) -> Option<BlockDevice> {
         path.file_name().and_then(|file_name| {
             let path = PathBuf::from("/sys/class/block/").join(file_name);
             if path.exists() {
-                Some(BlockDevice { path })
+                Some(BlockDevice { path, timeout })
             } else {
                 None
             }
@@ -38,7 +38,7 @@ impl BlockDevice {
         let get_sectors = || read_file(&self.path.join("size")).parse::<u64>().unwrap_or(0);
         let (mut result, mut attempts) = (get_sectors(), 0);
 
-        while result == 0 || attempts == ATTEMPTS {
+        while result == 0 || attempts == self.timeout / SLEEP_AFTER_FAIL {
             result = get_sectors();
             sleep(Duration::from_millis(SLEEP_AFTER_FAIL));
             attempts += 1;


### PR DESCRIPTION
This may fix #52 

- The initial device size detection timeout is now 0s
- Asynchronous device refreshes use a timeout of 5s.