### PR TITLE
Check if the hashes correspond if a hash is already present

### DIFF
--- a/gtk/src/app/signals/images.rs
+++ b/gtk/src/app/signals/images.rs
@@ -21,7 +21,7 @@ impl App {
     pub fn connect_hash(&self) {
         let state = self.state.clone();
         let ui = self.ui.clone();
-        self.ui.content.image_view.hash.connect_changed(move |_| {
+        self.ui.content.image_view.check.connect_clicked(move |_| {
             set_hash_widget(&state, &ui);
         });
     }
@@ -58,6 +58,7 @@ fn set_hash_widget(state: &State, ui: &GtkUi) {
     };
 
     ui.content.image_view.chooser_container.set_visible_child_name("checksum");
+    ui.content.image_view.set_hash_sensitive(false);
 
     let _ = state.back_event_tx.send(BackgroundEvent::GenerateHash(PathBuf::from(&*path), kind));
 }

--- a/gtk/src/app/signals/mod.rs
+++ b/gtk/src/app/signals/mod.rs
@@ -71,6 +71,7 @@ impl App {
                         Ok(hash) => hash,
                         Err(why) => format!("error: {}", why),
                     });
+                    ui.content.image_view.set_hash_sensitive(true);
 
                     ui.content.image_view.chooser_container.set_visible_child_name("chooser");
                 }
@@ -79,8 +80,7 @@ impl App {
                         let image_size = file.metadata().ok().map_or(0, |m| m.len());
 
                         ui.content.image_view.set_image_path(&path);
-                        ui.content.image_view.hash.set_sensitive(true);
-                        ui.content.image_view.hash_label.set_sensitive(true);
+                        ui.content.image_view.set_hash_sensitive(true);
                         ui.header.next.set_sensitive(true);
 
                         state.image_size.store(image_size, Ordering::SeqCst);

--- a/gtk/src/app/views/images.rs
+++ b/gtk/src/app/views/images.rs
@@ -53,9 +53,13 @@ impl ImageView {
             ..append_text("SHA256");
             ..append_text("MD5");
             ..set_active(0);
+            ..set_sensitive(false);
         };
 
-        let hash_label = Entry::new();
+        let hash_label = cascade! {
+            Entry::new();
+            ..set_sensitive(false);
+        };
 
         let label = cascade! {
             Label::new("Hash:");
@@ -65,6 +69,7 @@ impl ImageView {
         let check = cascade! {
             Button::new_with_label("Check");
             ..get_style_context().add_class(&STYLE_CLASS_SUGGESTED_ACTION);
+            ..set_sensitive(false);
         };
 
         let combo_container = cascade! {

--- a/gtk/src/app/views/mod.rs
+++ b/gtk/src/app/views/mod.rs
@@ -26,6 +26,7 @@ pub struct Content {
 impl Content {
     pub fn new() -> Content {
         let image_view = ImageView::new();
+        image_view.set_hash_sensitive(false);
         let devices_view = DevicesView::new();
         let flash_view = FlashView::new();
         let summary_view = SummaryView::new();

--- a/gtk/src/app/views/mod.rs
+++ b/gtk/src/app/views/mod.rs
@@ -26,7 +26,6 @@ pub struct Content {
 impl Content {
     pub fn new() -> Content {
         let image_view = ImageView::new();
-        image_view.set_hash_sensitive(false);
         let devices_view = DevicesView::new();
         let flash_view = FlashView::new();
         let summary_view = SummaryView::new();


### PR DESCRIPTION
- If the field already has text, verify that the hash matches it
- Add a Check button, rather than performing a check per dropdown
selection: avoids simultaneously running checks and let the user decide
when to start the check

TODO: Nicer theme?

Fix: #68