### PR TITLE
improvement: Ignore case in hash comparison

### DIFF
--- a/gtk/src/app/views/images.rs
+++ b/gtk/src/app/views/images.rs
@@ -129,7 +129,7 @@ impl ImageView {
 
     pub fn set_hash(&self, hash: &str) {
         if let Some(text) = self.hash_label.get_text().filter(|text| !text.is_empty()) {
-            if let Some(fg) = if text == hash {
+            if let Some(fg) = if text.eq_ignore_ascii_case(hash) {
                 Attribute::new_foreground(0, std::u16::MAX, 0)
             } else {
                 Attribute::new_foreground(std::u16::MAX, 0, 0)


### PR DESCRIPTION
Hi!

[Some sites](https://www.microsoft.com/en-us/software-download/windows10ISO) provide the files hashes in capital letters. This commit ignores the case in the comparison.

Afterwards:
![Screenshot from 2020-07-22 21-10-16](https://user-images.githubusercontent.com/5737978/88218864-f9e9d780-cc60-11ea-96fe-02b06bab1999.png)



