### PR TITLE
fix(gtk): Correctly handle error in FlashRequest::write()

### DIFF
--- a/gtk/src/flash.rs
+++ b/gtk/src/flash.rs
@@ -43,6 +43,17 @@ impl FlashRequest {
     }
 
     pub fn write(self) -> io::Result<Vec<io::Result<()>>> {
+        let finished = self.finished.clone();
+        let res = self.write_inner();
+        if res.is_err() {
+            for i in 0..finished.len() {
+                finished[i].store(true, Ordering::SeqCst);
+            }
+        }
+        res
+    }
+
+    fn write_inner(self) -> io::Result<Vec<io::Result<()>>> {
         let status = &self.status;
         let progress = &self.progress;
         let finished = &self.finished;


### PR DESCRIPTION
`App::connect_ui_events()` doesn't try to join the flashing thread until `all_tasks_finished` is `true`. So an error in `FlashRequest::write()` before all destinations are marked finished resulted in an invisible error with the UI showing no progress. This fixes that by setting finished for each destination on error.

To reproduce the issue, run `popsicle-gtk` as a non-root user.

If the plan is to update Popsicle to using async in the GUI, perhaps this could be handled in a better way as part of that change.