### PR TITLE
feat(gtk): Use FileChooserNative instead of FileChooserDialog

### DIFF
--- a/gtk/src/app/widgets/dialogs.rs
+++ b/gtk/src/app/widgets/dialogs.rs
@@ -1,20 +1,20 @@
 use gtk::*;
 use std::path::PathBuf;
 
-/// A wrapped FileChooserDialog that automatically destroys itself upon being dropped.
-pub struct OpenDialog(FileChooserDialog);
+/// A wrapped FileChooserNative that automatically destroys itself upon being dropped.
+pub struct OpenDialog(FileChooserNative);
 
 impl OpenDialog {
     pub fn new(path: Option<PathBuf>) -> OpenDialog {
         #[allow(unused_mut)]
         OpenDialog(cascade! {
-            dialog: FileChooserDialog::new(
+            dialog: FileChooserNative::new(
                 Some("Open"),
                 Some(&Window::new(WindowType::Popup)),
                 FileChooserAction::Open,
+                Some("Open"),
+                Some("Cancel"),
             );
-            ..add_button("Cancel", ResponseType::Cancel.into());
-            ..add_button("Open", ResponseType::Ok.into());
             ..set_filter(&cascade! {
                 FileFilter::new();
                 ..add_pattern("*.[Ii][Ss][Oo]");
@@ -27,7 +27,7 @@ impl OpenDialog {
     }
 
     pub fn run(&self) -> Option<PathBuf> {
-        if self.0.run() == ResponseType::Ok.into() {
+        if self.0.run() == ResponseType::Accept {
             self.0.get_filename()
         } else {
             None
@@ -37,6 +37,6 @@ impl OpenDialog {
 
 impl Drop for OpenDialog {
     fn drop(&mut self) {
-        self.0.close();
+        self.0.destroy();
     }
 }


### PR DESCRIPTION
This should normally behave the exact same way, but in a Flatpak sandbox it will open a file chooser outside the sandbox using org.freedesktop.portal.FileChooser.

This will also use native Windows/macOS file dialogs, if Popsicle were to ever support Windows or Mac.