### PR TITLE
fix(gtk): Use `%f` instead of `%U` in .desktop

### DIFF
--- a/gtk/assets/com.system76.Popsicle.desktop
+++ b/gtk/assets/com.system76.Popsicle.desktop
@@ -9,4 +9,4 @@ Keywords="USB;Flash;Drive;Popsicle;"
 MimeType=application/x-cd-image;application/x-raw-disk-image;
 Terminal=false
 StartupNotify=true
-Exec=/usr/local/bin/popsicle-gtk %U
+Exec=/usr/local/bin/popsicle-gtk %f


### PR DESCRIPTION
Apparently `%U` means a "list of URIs", while `%f` is a single local file path. Since that's all it supports, this should probably be `%f`.

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html