### PR TITLE
Add appimagecraft build script

### DIFF
--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -1,0 +1,27 @@
+version: 1
+
+project:
+  name: com.github.pop-os.popsicle
+  version_command: git describe --tags
+
+build:
+  script:
+    commands:
+      # unfortunately, no out-of-source builds are possible (yet)
+      - pushd "$PROJECT_ROOT"
+      - make install DESTDIR="$(readlink -f "$BUILD_DIR"/AppDir)" prefix=/usr
+      - popd
+
+scripts:
+  post_build:
+    # just USB Flasher might make sense on Pop!_OS, but not on other distros
+    - sed -i 's|Name=USB Flasher|Name=Popsicle USB Flasher|' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+    # these fixes can likely be removed when #105 is merged
+    - sed -i 's|System$|System;|' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+    - sed -i 's|/usr/local/bin/||g' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+    - sed -i 's|/usr/bin/||g' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+
+appimage:
+  linuxdeploy:
+    plugins:
+      - gtk


### PR DESCRIPTION
Allows Popsicle to be built as an AppImage with [appimagecraft](https://github.com/TheAssassin/appimagecraft).

CC #104.