### PR TITLE
Appimage recipe, CI, and bumping version to 1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+on: [push, pull_request]
+
+name: ci
+
+jobs:
+  appimage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: docker run --rm -v "$PWD:/popsicle" -w "/popsicle" rust:1.40.0-stretch bash appimage.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        if-no-files-found: error
+        name: popsicle-appimage-${{ github.sha }}
+        path: Popsicle_USB_Flasher-*.AppImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
 
 name: ci
 
@@ -15,3 +19,21 @@ jobs:
         if-no-files-found: error
         name: popsicle-appimage-${{ github.sha }}
         path: Popsicle_USB_Flasher-*.AppImage
+
+  upload-to-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs: appimage
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: popsicle-appimage-${{ github.sha }}
+    - run: printf 'APPIMAGE_FILENAME=%s\n' Popsicle_USB_Flasher-*.AppImage > $GITHUB_ENV
+    - uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ env.APPIMAGE_FILENAME }}
+        asset_name: ${{ env.APPIMAGE_FILENAME }}
+        asset_content_type: application/vnd.appimage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "popsicle"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "as-result 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "popsicle_cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1107,12 +1107,12 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "popsicle 1.1.0",
+ "popsicle 1.2.0",
 ]
 
 [[package]]
 name = "popsicle_gtk"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1132,7 +1132,7 @@ dependencies = [
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pango 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "popsicle 1.1.0",
+ "popsicle 1.2.0",
  "proc-mounts 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwd 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "popsicle"
 description = "USB Flasher"
-version = "1.1.0"
+version = "1.2.0"
 authors = [
     "Jeremy Soller <jeremy@system76.com>",
     "Michael Aaron Murphy <michael@system76.com>",

--- a/appimage.sh
+++ b/appimage.sh
@@ -1,0 +1,8 @@
+set -e
+
+export APPIMAGE_EXTRACT_AND_RUN=1
+apt-get update
+apt-get install -y libgtk-3-dev
+wget https://github.com/TheAssassin/appimagecraft/releases/download/continuous/appimagecraft-x86_64.AppImage
+chmod +x appimagecraft-x86_64.AppImage
+./appimagecraft-x86_64.AppImage

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -1,0 +1,27 @@
+version: 1
+
+project:
+  name: com.github.pop-os.popsicle
+  version_command: git describe --tags
+
+build:
+  script:
+    commands:
+      # unfortunately, no out-of-source builds are possible (yet)
+      - pushd "$PROJECT_ROOT"
+      - make install DESTDIR="$(readlink -f "$BUILD_DIR"/AppDir)" prefix=/usr
+      - popd
+
+scripts:
+  post_build:
+    # just USB Flasher might make sense on Pop!_OS, but not on other distros
+    - sed -i 's|Name=USB Flasher|Name=Popsicle USB Flasher|' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+    # these fixes can likely be removed when #105 is merged
+    - sed -i 's|System$|System;|' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+    - sed -i 's|/usr/local/bin/||g' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+    - sed -i 's|/usr/bin/||g' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
+
+appimage:
+  linuxdeploy:
+    plugins:
+      - gtk

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "popsicle_cli"
 description = "USB Flasher"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 license = "MIT"
 readme = "README.md"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+popsicle (1.2.0) groovy; urgency=medium
+
+  * 1.2.0 Release 
+
+ -- Ian Douglas Scott <idscott@system76.com>  Tue, 27 Oct 2020 13:42:44 -0700
+
 popsicle (1.1.0) focal; urgency=medium
 
   * 1.1.0 release

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "popsicle_gtk"
 description = "USB Flasher"
-version = "1.1.0"
+version = "1.2.0"
 authors = [ "Michael Aaron Murphy <michael@system76.com>" ]
 license = "MIT"
 readme = "README.md"

--- a/gtk/assets/com.system76.Popsicle.appdata.xml
+++ b/gtk/assets/com.system76.Popsicle.appdata.xml
@@ -55,5 +55,6 @@
 	<content_rating type="oars-1.0" />
 	<releases>
 		<release version="1.1.0" date="2020-08-03" />
+		<release version="1.2.0" date="2020-10-27" />
 	</releases>
 </component>


### PR DESCRIPTION
This includes the appimagecraft script from https://github.com/pop-os/popsicle/pull/106, as well as a GitHub actions workflow to automatically build the appimage and attach it to releases (which I've tested on a fork).

This also bumps the version to 1.2.0.

If accepted, I'll tag a release, and update the Flatpak as well.