### PR TITLE
fix(cli): Fix checking

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -91,6 +91,8 @@ impl<P: Progress> Task<P> {
             pb.message(&path, "S", "");
         }
 
+        self.image.seek(SeekFrom::Start(0)).await?;
+
         let mut stream = self.writer.seek(SeekFrom::Start(0));
         while let Some((entity, why)) = stream.next().await {
             let (path, mut pb) = self.state.remove(&entity).expect("missing entity");


### PR DESCRIPTION
This didn't seek the image file, so it didn't check any bytes.

Now `popsicle --check` takes some time to check the written data, instead of "succeeding" immediately with no progress shown.