### PR TITLE
i18n(pt_BR): Add Brazilian Portuguese .desktop translations

### DIFF
--- a/gtk/assets/com.system76.Popsicle.desktop
+++ b/gtk/assets/com.system76.Popsicle.desktop
@@ -1,11 +1,15 @@
 [Desktop Entry]
 Type=Application
 Name=USB Flasher
+Name[pt_BR]=Gravador USB
 GenericName=USB Flasher
+GenericName[pt_BR]=Gravador USB
 X-GNOME-FullName=USB Flasher
+X-GNOME-FullName[pt_BR]=Gravador USB
 Icon=com.system76.Popsicle
 Categories=System;
 Keywords="USB;Flash;Drive;Popsicle;"
+Keywords[pt_BR]="USB;Gravar;Pendrive;Popsicle;"
 MimeType=application/x-cd-image;application/x-raw-disk-image;
 Terminal=false
 StartupNotify=true


### PR DESCRIPTION
Adds Brazilian Portuguese names and keywords to the .desktop file