### PR TITLE
Add support for AppImageUpdate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         if-no-files-found: error
         name: popsicle-appimage-${{ github.sha }}
-        path: Popsicle_USB_Flasher-*.AppImage
+        path: Popsicle_USB_Flasher-*.AppImage*
 
   upload-to-release:
     if: github.event_name == 'release'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ debian/*
 target/
 vendor/
 vendor.tar
+*.AppImage*
+*.zsync
+*.swp
+.appimagecraft-*/

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -19,5 +19,7 @@ scripts:
 
 appimage:
   linuxdeploy:
+    environment:
+      UPD_INFO: 'gh-releases-zsync|pop-os|popsicle|latest|Popsicle_USB_Flasher-*x86_64.AppImage.zsync'
     plugins:
       - gtk

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -16,10 +16,6 @@ scripts:
   post_build:
     # just USB Flasher might make sense on Pop!_OS, but not on other distros
     - sed -i 's|Name=USB Flasher|Name=Popsicle USB Flasher|' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
-    # these fixes can likely be removed when #105 is merged
-    - sed -i 's|System$|System;|' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
-    - sed -i 's|/usr/local/bin/||g' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
-    - sed -i 's|/usr/bin/||g' "$BUILD_DIR"/AppDir/usr/share/applications/com.system76.Popsicle.desktop
 
 appimage:
   linuxdeploy:


### PR DESCRIPTION
Closes #121.

Please note that the release upload part still needs to be updated to include the `.zsync` file. I have never used this `upload-release-asset" action before.