### PR TITLE
A few UI tweaks

### DIFF
--- a/gtk/src/app/signals/mod.rs
+++ b/gtk/src/app/signals/mod.rs
@@ -294,6 +294,8 @@ impl App {
                                     description.set_text(&desc);
                                     list.hide();
                                 } else {
+                                    ui.content.summary_view.view.topic.set_text(&fl!("flashing-completed-with-errors"));
+
                                     let mut desc = fl!(
                                         "partial-flash",
                                         number = {ntasks - errors.len()},

--- a/gtk/src/app/signals/mod.rs
+++ b/gtk/src/app/signals/mod.rs
@@ -317,7 +317,13 @@ impl App {
                                             ..pack_start(&why, true, true, 0);
                                         };
 
-                                        list.insert(&container, -1);
+                                        let row = cascade! {
+                                            gtk::ListBoxRow::new();
+                                            ..set_selectable(false);
+                                            ..add(&container);
+                                        };
+
+                                        list.add(&row);
                                     }
 
                                     list.show_all();

--- a/gtk/src/app/views/devices.rs
+++ b/gtk/src/app/views/devices.rs
@@ -23,6 +23,7 @@ impl DevicesView {
     pub fn new() -> DevicesView {
         let list = cascade! {
             gtk::ListBox::new();
+            ..get_style_context().add_class("frame");
             ..get_style_context().add_class("devices");
             ..set_hexpand(true);
             ..set_vexpand(true);
@@ -51,7 +52,6 @@ impl DevicesView {
         let list_box = cascade! {
             gtk::Box::new(gtk::Orientation::Vertical, 0);
             ..add(&select_all);
-            ..add(&gtk::Separator::new(gtk::Orientation::Horizontal));
             ..add(&list);
         };
 

--- a/gtk/src/app/views/summary.rs
+++ b/gtk/src/app/views/summary.rs
@@ -9,8 +9,10 @@ pub struct SummaryView {
 
 impl SummaryView {
     pub fn new() -> SummaryView {
-        let list = ListBox::new();
-        list.set_visible(false);
+        let list = cascade! {
+            ListBox::new();
+            ..get_style_context().add_class("frame");
+        };
 
         let view = View::new("process-completed", &fl!("flashing-completed"), "", |right_panel| {
             right_panel.pack_start(&list, true, true, 0);

--- a/i18n/en/popsicle_gtk.ftl
+++ b/i18n/en/popsicle_gtk.ftl
@@ -24,6 +24,7 @@ flash-view-title = Flashing Devices
 
 # Summary View
 flashing-completed = Flashing Completed
+flashing-completed-with-errors = Flashing Completed with Errors
 flash-again = Flash Again
 
 # Error View


### PR DESCRIPTION
This changes the message when flashing errors to improve the confusing behavior involved in https://github.com/pop-os/popsicle/issues/120. Not sure what icon might be better in that case.

It also adds a frame to `ListBox`es which seems better (this matches how all of Gnome Control Center's `ListBox`es are styled, for instance), and doesn't allow selection of rows in the summary.