### PR TITLE
Add Flatpak manifest

### DIFF
--- a/com.system76.Popsicle.json
+++ b/com.system76.Popsicle.json
@@ -1,0 +1,43 @@
+{
+    "app-id" : "com.system76.Popsicle",
+    "runtime" : "org.freedesktop.Platform",
+    "runtime-version" : "22.08",
+    "sdk" : "org.freedesktop.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "build-options" : {
+        "append-path" : "/usr/lib/sdk/rust-stable/bin",
+        "env" : {
+            "CARGO_HOME" : "/run/build/popsicle/cargo"
+        }
+    },
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--system-talk-name=org.freedesktop.UDisks2"
+    ],
+    "command" : "popsicle-gtk",
+    "cleanup" : [
+        "/share/icons/hicolor/512x512@2x"
+    ],
+    "modules" : [
+        {
+            "name" : "popsicle",
+            "buildsystem" : "simple",
+            "sources" : [
+                {
+                    "type" : "dir",
+                    "path" : "."
+                },
+                "generated-sources.json"
+            ],
+            "build-commands" : [
+                "sed -i 's|</launchable>|</launchable>\\n<icon type=\"remote\" height=\"512\" width=\"512\">https://raw.githubusercontent.com/pop-os/popsicle/master/gtk/assets/icons/512x512/apps/com.system76.Popsicle.png</icon>|' gtk/assets/com.system76.Popsicle.appdata.xml",
+                "make",
+                "make install prefix=/app"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This matches the manifest at Flathub, with the following changes:

- Bumps FreeDesktop runtime to 22.08 since 20.08 is EOL
- Changes the source to point to the current dir instead of the remote release archive

The reason for adding the manifest in-tree is that it enables using GNOME Builder to one-click build and run Popsicle; this makes it far, far easier for people like me to contribute. :smile: 