### PR TITLE
GitHub Actions: Add Flatpak action

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-42
+      image: flatpak/flatpak-github-actions:gnome-42
       options: --privileged
 
     strategy:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -28,7 +28,7 @@ jobs:
         platforms: arm64
       if: ${{ matrix.arch == 'aarch64' }}
 
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: Popsicle.flatpak
         manifest-path: com.system76.Popsicle.json

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,36 @@
+name: Flatpak
+on: [push, pull_request]
+jobs:
+  flatpak:
+    runs-on: ubuntu-latest
+
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-42
+      options: --privileged
+
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+      # Don't fail the whole workflow if one architecture fails
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install deps
+      run: |
+        dnf -y install docker
+      if: ${{ matrix.arch == 'aarch64' }}
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64
+      if: ${{ matrix.arch == 'aarch64' }}
+
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+      with:
+        bundle: Popsicle.flatpak
+        manifest-path: com.system76.Popsicle.json
+        cache-key: "flatpak-builder-${{ github.sha }}"
+        arch: ${{ matrix.arch }}

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,0 +1,2249 @@
+[
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/ansi_term/ansi_term-0.11.0.crate",
+        "sha256": "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b",
+        "dest": "cargo/vendor",
+        "dest-filename": "ansi_term-0.11.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/ansi_term-0.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.25.crate",
+        "sha256": "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14",
+        "dest": "cargo/vendor",
+        "dest-filename": "anyhow-1.0.25.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/anyhow-1.0.25",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.5.1.crate",
+        "sha256": "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8",
+        "dest": "cargo/vendor",
+        "dest-filename": "arrayvec-0.5.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/arrayvec-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/as-result/as-result-0.2.1.crate",
+        "sha256": "3702cac3c1601410cd655ae41650c4c87f7c3183dca6d1cd9acc4220ed56a8b7",
+        "dest": "cargo/vendor",
+        "dest-filename": "as-result-0.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223702cac3c1601410cd655ae41650c4c87f7c3183dca6d1cd9acc4220ed56a8b7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/as-result-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/async-std/async-std-1.4.0.crate",
+        "sha256": "0bf6039b315300e057d198b9d3ab92ee029e31c759b7f1afae538145e6f18a3e",
+        "dest": "cargo/vendor",
+        "dest-filename": "async-std-1.4.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220bf6039b315300e057d198b9d3ab92ee029e31c759b7f1afae538145e6f18a3e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/async-std-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/async-task/async-task-1.0.0.crate",
+        "sha256": "de6bd58f7b9cc49032559422595c81cbfcf04db2f2133592f70af19e258a1ced",
+        "dest": "cargo/vendor",
+        "dest-filename": "async-task-1.0.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22de6bd58f7b9cc49032559422595c81cbfcf04db2f2133592f70af19e258a1ced%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/async-task-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/atk/atk-0.9.0.crate",
+        "sha256": "812b4911e210bd51b24596244523c856ca749e6223c50a7fbbba3f89ee37c426",
+        "dest": "cargo/vendor",
+        "dest-filename": "atk-0.9.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22812b4911e210bd51b24596244523c856ca749e6223c50a7fbbba3f89ee37c426%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/atk-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/atk-sys/atk-sys-0.10.0.crate",
+        "sha256": "f530e4af131d94cc4fa15c5c9d0348f0ef28bac64ba660b6b2a1cf2605dedfce",
+        "dest": "cargo/vendor",
+        "dest-filename": "atk-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f530e4af131d94cc4fa15c5c9d0348f0ef28bac64ba660b6b2a1cf2605dedfce%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/atk-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/atomic/atomic-0.4.5.crate",
+        "sha256": "c210c1f4db048cda477b652d170572d84c9640695835f17663595d3bd543fc28",
+        "dest": "cargo/vendor",
+        "dest-filename": "atomic-0.4.5.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c210c1f4db048cda477b652d170572d84c9640695835f17663595d3bd543fc28%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/atomic-0.4.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/atty/atty-0.2.13.crate",
+        "sha256": "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90",
+        "dest": "cargo/vendor",
+        "dest-filename": "atty-0.2.13.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/atty-0.2.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/autocfg/autocfg-0.1.7.crate",
+        "sha256": "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2",
+        "dest": "cargo/vendor",
+        "dest-filename": "autocfg-0.1.7.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/autocfg-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/backtrace/backtrace-0.3.40.crate",
+        "sha256": "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea",
+        "dest": "cargo/vendor",
+        "dest-filename": "backtrace-0.3.40.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/backtrace-0.3.40",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/backtrace-sys/backtrace-sys-0.1.32.crate",
+        "sha256": "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491",
+        "dest": "cargo/vendor",
+        "dest-filename": "backtrace-sys-0.1.32.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/backtrace-sys-0.1.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/base64/base64-0.10.1.crate",
+        "sha256": "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e",
+        "dest": "cargo/vendor",
+        "dest-filename": "base64-0.10.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/base64-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/better-panic/better-panic-0.2.0.crate",
+        "sha256": "3d12a680cc74d8c4a44ee08be4a00dedf671b089c2440b2e3fdaa776cd468476",
+        "dest": "cargo/vendor",
+        "dest-filename": "better-panic-0.2.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223d12a680cc74d8c4a44ee08be4a00dedf671b089c2440b2e3fdaa776cd468476%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/better-panic-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-1.2.1.crate",
+        "sha256": "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693",
+        "dest": "cargo/vendor",
+        "dest-filename": "bitflags-1.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/bitflags-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/block-buffer/block-buffer-0.7.3.crate",
+        "sha256": "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b",
+        "dest": "cargo/vendor",
+        "dest-filename": "block-buffer-0.7.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/block-buffer-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/block-padding/block-padding-0.1.5.crate",
+        "sha256": "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5",
+        "dest": "cargo/vendor",
+        "dest-filename": "block-padding-0.1.5.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/block-padding-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/byte-tools/byte-tools-0.3.1.crate",
+        "sha256": "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7",
+        "dest": "cargo/vendor",
+        "dest-filename": "byte-tools-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/byte-tools-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/byteorder/byteorder-1.3.2.crate",
+        "sha256": "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5",
+        "dest": "cargo/vendor",
+        "dest-filename": "byteorder-1.3.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/byteorder-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/bytes/bytes-0.5.3.crate",
+        "sha256": "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38",
+        "dest": "cargo/vendor",
+        "dest-filename": "bytes-0.5.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2210004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/bytes-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/bytesize/bytesize-1.0.1.crate",
+        "sha256": "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da",
+        "dest": "cargo/vendor",
+        "dest-filename": "bytesize-1.0.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2281a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/bytesize-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.9.1.crate",
+        "sha256": "c5c0f2e047e8ca53d0ff249c54ae047931d7a6ebe05d00af73e0ffeb6e34bdb8",
+        "dest": "cargo/vendor",
+        "dest-filename": "cairo-rs-0.9.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c5c0f2e047e8ca53d0ff249c54ae047931d7a6ebe05d00af73e0ffeb6e34bdb8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cairo-rs-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.10.0.crate",
+        "sha256": "2ed2639b9ad5f1d6efa76de95558e11339e7318426d84ac4890b86c03e828ca7",
+        "dest": "cargo/vendor",
+        "dest-filename": "cairo-sys-rs-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222ed2639b9ad5f1d6efa76de95558e11339e7318426d84ac4890b86c03e828ca7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cairo-sys-rs-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/cascade/cascade-0.1.4.crate",
+        "sha256": "31c9ddf4a1a9dbf82e130117f81b0c292fb5416000cbaba11eb92a65face2613",
+        "dest": "cargo/vendor",
+        "dest-filename": "cascade-0.1.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2231c9ddf4a1a9dbf82e130117f81b0c292fb5416000cbaba11eb92a65face2613%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cascade-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/cc/cc-1.0.48.crate",
+        "sha256": "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76",
+        "dest": "cargo/vendor",
+        "dest-filename": "cc-1.0.48.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cc-1.0.48",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-0.1.10.crate",
+        "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+        "dest": "cargo/vendor",
+        "dest-filename": "cfg-if-0.1.10.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cfg-if-0.1.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/clap/clap-2.33.0.crate",
+        "sha256": "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9",
+        "dest": "cargo/vendor",
+        "dest-filename": "clap-2.33.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/clap-2.33.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/clicolors-control/clicolors-control-1.0.1.crate",
+        "sha256": "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e",
+        "dest": "cargo/vendor",
+        "dest-filename": "clicolors-control-1.0.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2290082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/clicolors-control-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/cloudabi/cloudabi-0.0.3.crate",
+        "sha256": "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f",
+        "dest": "cargo/vendor",
+        "dest-filename": "cloudabi-0.0.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cloudabi-0.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/console/console-0.9.1.crate",
+        "sha256": "f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f",
+        "dest": "cargo/vendor",
+        "dest-filename": "console-0.9.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/console-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.4.0.crate",
+        "sha256": "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c",
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-channel-0.4.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/crossbeam-channel-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.7.2.crate",
+        "sha256": "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca",
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-deque-0.7.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/crossbeam-deque-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.8.0.crate",
+        "sha256": "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac",
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-epoch-0.8.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/crossbeam-epoch-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.6.6.crate",
+        "sha256": "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6",
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-utils-0.6.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2204973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/crossbeam-utils-0.6.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.7.0.crate",
+        "sha256": "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4",
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-utils-0.7.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/crossbeam-utils-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/dbus/dbus-0.9.0.crate",
+        "sha256": "22c08adfeb70c940c14d8af988fa854dcb5529e6141f2397e4e0fa4c9375d094",
+        "dest": "cargo/vendor",
+        "dest-filename": "dbus-0.9.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2222c08adfeb70c940c14d8af988fa854dcb5529e6141f2397e4e0fa4c9375d094%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/dbus-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "git",
+        "url": "https://github.com/pop-os/dbus-udisks2",
+        "commit": "15c4e70f029c6546e96f8c5b2fb78c9504cf9f28",
+        "dest": "cargo/vendor/dbus-udisks2"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20null%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/dbus-udisks2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/derivative/derivative-2.1.1.crate",
+        "sha256": "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f",
+        "dest": "cargo/vendor",
+        "dest-filename": "derivative-2.1.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/derivative-2.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/derive-new/derive-new-0.5.8.crate",
+        "sha256": "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9",
+        "dest": "cargo/vendor",
+        "dest-filename": "derive-new-0.5.8.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2271f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/derive-new-0.5.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/digest/digest-0.8.1.crate",
+        "sha256": "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5",
+        "dest": "cargo/vendor",
+        "dest-filename": "digest-0.8.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/digest-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/either/either-1.5.3.crate",
+        "sha256": "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3",
+        "dest": "cargo/vendor",
+        "dest-filename": "either-1.5.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/either-1.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/encode_unicode/encode_unicode-0.3.6.crate",
+        "sha256": "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f",
+        "dest": "cargo/vendor",
+        "dest-filename": "encode_unicode-0.3.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/encode_unicode-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/errno/errno-0.2.4.crate",
+        "sha256": "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e",
+        "dest": "cargo/vendor",
+        "dest-filename": "errno-0.2.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/errno-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/errno-dragonfly/errno-dragonfly-0.1.1.crate",
+        "sha256": "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067",
+        "dest": "cargo/vendor",
+        "dest-filename": "errno-dragonfly-0.1.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2214ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/errno-dragonfly-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/failure/failure-0.1.6.crate",
+        "sha256": "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9",
+        "dest": "cargo/vendor",
+        "dest-filename": "failure-0.1.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/failure-0.1.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/failure_derive/failure_derive-0.1.6.crate",
+        "sha256": "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08",
+        "dest": "cargo/vendor",
+        "dest-filename": "failure_derive-0.1.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/failure_derive-0.1.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/fake-simd/fake-simd-0.1.2.crate",
+        "sha256": "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed",
+        "dest": "cargo/vendor",
+        "dest-filename": "fake-simd-0.1.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/fake-simd-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/fomat-macros/fomat-macros-0.3.1.crate",
+        "sha256": "fe56556a8c9f9f556150eb6b390bc1a8b3715fd2ddbb4585f36b6a5672c6a833",
+        "dest": "cargo/vendor",
+        "dest-filename": "fomat-macros-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fe56556a8c9f9f556150eb6b390bc1a8b3715fd2ddbb4585f36b6a5672c6a833%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/fomat-macros-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/fuchsia-zircon/fuchsia-zircon-0.3.3.crate",
+        "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
+        "dest": "cargo/vendor",
+        "dest-filename": "fuchsia-zircon-0.3.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/fuchsia-zircon-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/fuchsia-zircon-sys/fuchsia-zircon-sys-0.3.3.crate",
+        "sha256": "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
+        "dest": "cargo/vendor",
+        "dest-filename": "fuchsia-zircon-sys-0.3.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/fuchsia-zircon-sys-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures/futures-0.3.1.crate",
+        "sha256": "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.1.crate",
+        "sha256": "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-channel-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-channel-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.1.crate",
+        "sha256": "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-core-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2279564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-core-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.1.crate",
+        "sha256": "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-executor-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-executor-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.1.crate",
+        "sha256": "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-io-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-io-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.1.crate",
+        "sha256": "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-macro-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2252e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-macro-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.1.crate",
+        "sha256": "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-sink-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-sink-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.1.crate",
+        "sha256": "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-task-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-task-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-timer/futures-timer-2.0.2.crate",
+        "sha256": "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-timer-2.0.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-timer-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.1.crate",
+        "sha256": "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-util-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures-util-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/futures_codec/futures_codec-0.3.4.crate",
+        "sha256": "a0a73299e4718f5452e45980fc1d6957a070abe308d3700b63b8673f47e1c2b3",
+        "dest": "cargo/vendor",
+        "dest-filename": "futures_codec-0.3.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a0a73299e4718f5452e45980fc1d6957a070abe308d3700b63b8673f47e1c2b3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/futures_codec-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gcc/gcc-0.3.55.crate",
+        "sha256": "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2",
+        "dest": "cargo/vendor",
+        "dest-filename": "gcc-0.3.55.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gcc-0.3.55",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gdk/gdk-0.13.0.crate",
+        "sha256": "7764140c1246a19ce9b5f7e8b760f7d11644651a8e18a64873e9980cd68ba558",
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk-0.13.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227764140c1246a19ce9b5f7e8b760f7d11644651a8e18a64873e9980cd68ba558%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gdk-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.9.0.crate",
+        "sha256": "8f6dae3cb99dd49b758b88f0132f8d401108e63ae8edd45f432d42cdff99998a",
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk-pixbuf-0.9.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228f6dae3cb99dd49b758b88f0132f8d401108e63ae8edd45f432d42cdff99998a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gdk-pixbuf-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.10.0.crate",
+        "sha256": "3bfe468a7f43e97b8d193a762b6c5cf67a7d36cacbc0b9291dbcae24bfea1e8f",
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk-pixbuf-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223bfe468a7f43e97b8d193a762b6c5cf67a7d36cacbc0b9291dbcae24bfea1e8f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gdk-sys/gdk-sys-0.10.0.crate",
+        "sha256": "0a9653cfc500fd268015b1ac055ddbc3df7a5c9ea3f4ccef147b3957bd140d69",
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220a9653cfc500fd268015b1ac055ddbc3df7a5c9ea3f4ccef147b3957bd140d69%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gdk-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/genawaiter/genawaiter-0.2.2.crate",
+        "sha256": "1236259ce812baf9e1d1e316724e0fec341ce788f038aa543f813dfe78e12d32",
+        "dest": "cargo/vendor",
+        "dest-filename": "genawaiter-0.2.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221236259ce812baf9e1d1e316724e0fec341ce788f038aa543f813dfe78e12d32%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/genawaiter-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/generic-array/generic-array-0.12.3.crate",
+        "sha256": "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec",
+        "dest": "cargo/vendor",
+        "dest-filename": "generic-array-0.12.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/generic-array-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gio/gio-0.9.0.crate",
+        "sha256": "3c5492e80b45e6c56214894a9a0cbe1340ab5066eb44a2dbe151393b6d7942c0",
+        "dest": "cargo/vendor",
+        "dest-filename": "gio-0.9.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223c5492e80b45e6c56214894a9a0cbe1340ab5066eb44a2dbe151393b6d7942c0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gio-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.10.0.crate",
+        "sha256": "35993626299fbcaa73c0a19be8fdd01c950f9f3d3ac9cb4fb5532b924ab1a5d7",
+        "dest": "cargo/vendor",
+        "dest-filename": "gio-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2235993626299fbcaa73c0a19be8fdd01c950f9f3d3ac9cb4fb5532b924ab1a5d7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gio-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/glib/glib-0.10.1.crate",
+        "sha256": "a5e0533f48640d86e8e2f3cee778a9f97588d4a0bec8be065ee51ea52346d6c1",
+        "dest": "cargo/vendor",
+        "dest-filename": "glib-0.10.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a5e0533f48640d86e8e2f3cee778a9f97588d4a0bec8be065ee51ea52346d6c1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/glib-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.10.1.crate",
+        "sha256": "41486a26d1366a8032b160b59065a59fb528530a46a49f627e7048fb8c064039",
+        "dest": "cargo/vendor",
+        "dest-filename": "glib-macros-0.10.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2241486a26d1366a8032b160b59065a59fb528530a46a49f627e7048fb8c064039%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/glib-macros-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.10.0.crate",
+        "sha256": "b6cda4af5c2f4507b7a3535b798dca2135293f4bc3a17f399ce244ef15841c4c",
+        "dest": "cargo/vendor",
+        "dest-filename": "glib-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b6cda4af5c2f4507b7a3535b798dca2135293f4bc3a17f399ce244ef15841c4c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/glib-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.10.0.crate",
+        "sha256": "952133b60c318a62bf82ee75b93acc7e84028a093e06b9e27981c2b6fe68218c",
+        "dest": "cargo/vendor",
+        "dest-filename": "gobject-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22952133b60c318a62bf82ee75b93acc7e84028a093e06b9e27981c2b6fe68218c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gobject-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gtk/gtk-0.9.1.crate",
+        "sha256": "04e8dfefe08ae2c0e3a8a221a5440a891a5e3402ba7c01078182f700c38ef345",
+        "dest": "cargo/vendor",
+        "dest-filename": "gtk-0.9.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2204e8dfefe08ae2c0e3a8a221a5440a891a5e3402ba7c01078182f700c38ef345%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gtk-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/gtk-sys/gtk-sys-0.10.0.crate",
+        "sha256": "89acda6f084863307d948ba64a4b1ef674e8527dddab147ee4cdcc194c880457",
+        "dest": "cargo/vendor",
+        "dest-filename": "gtk-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2289acda6f084863307d948ba64a4b1ef674e8527dddab147ee4cdcc194c880457%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/gtk-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/heck/heck-0.3.1.crate",
+        "sha256": "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205",
+        "dest": "cargo/vendor",
+        "dest-filename": "heck-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2220564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/heck-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.1.5.crate",
+        "sha256": "f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7",
+        "dest": "cargo/vendor",
+        "dest-filename": "hermit-abi-0.1.5.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/hermit-abi-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/hex-view/hex-view-0.1.3.crate",
+        "sha256": "494e16c9fe4dd02a88f3fe9ec0f27e38045691ea0ceb11603670f220ff5ca97f",
+        "dest": "cargo/vendor",
+        "dest-filename": "hex-view-0.1.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22494e16c9fe4dd02a88f3fe9ec0f27e38045691ea0ceb11603670f220ff5ca97f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/hex-view-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/iovec/iovec-0.1.4.crate",
+        "sha256": "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
+        "dest": "cargo/vendor",
+        "dest-filename": "iovec-0.1.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/iovec-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "git",
+        "url": "https://github.com/ids1024/iso9660-rs",
+        "commit": "241b8743f4b131e0cf45ebbb85eab000219af027",
+        "dest": "cargo/vendor/iso9660"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20null%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/iso9660",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/itertools/itertools-0.9.0.crate",
+        "sha256": "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b",
+        "dest": "cargo/vendor",
+        "dest-filename": "itertools-0.9.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/itertools-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/kernel32-sys/kernel32-sys-0.2.2.crate",
+        "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
+        "dest": "cargo/vendor",
+        "dest-filename": "kernel32-sys-0.2.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/kernel32-sys-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/kv-log-macro/kv-log-macro-1.0.4.crate",
+        "sha256": "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb",
+        "dest": "cargo/vendor",
+        "dest-filename": "kv-log-macro-1.0.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/kv-log-macro-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.4.0.crate",
+        "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+        "dest": "cargo/vendor",
+        "dest-filename": "lazy_static-1.4.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/lazy_static-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/lexical-core/lexical-core-0.7.4.crate",
+        "sha256": "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616",
+        "dest": "cargo/vendor",
+        "dest-filename": "lexical-core-0.7.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/lexical-core-0.7.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/libc/libc-0.2.66.crate",
+        "sha256": "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558",
+        "dest": "cargo/vendor",
+        "dest-filename": "libc-0.2.66.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/libc-0.2.66",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/libdbus-sys/libdbus-sys-0.2.1.crate",
+        "sha256": "dc12a3bc971424edbbf7edaf6e5740483444db63aa8e23d3751ff12a30f306f0",
+        "dest": "cargo/vendor",
+        "dest-filename": "libdbus-sys-0.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dc12a3bc971424edbbf7edaf6e5740483444db63aa8e23d3751ff12a30f306f0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/libdbus-sys-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.3.2.crate",
+        "sha256": "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586",
+        "dest": "cargo/vendor",
+        "dest-filename": "lock_api-0.3.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/lock_api-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/log/log-0.4.8.crate",
+        "sha256": "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7",
+        "dest": "cargo/vendor",
+        "dest-filename": "log-0.4.8.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2214b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/log-0.4.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/loopdev/loopdev-0.2.1.crate",
+        "sha256": "ac9e35cfb6646d67059f2ca8913a90e6c60633053c103df423975297f33d6fcc",
+        "dest": "cargo/vendor",
+        "dest-filename": "loopdev-0.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ac9e35cfb6646d67059f2ca8913a90e6c60633053c103df423975297f33d6fcc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/loopdev-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/md-5/md-5-0.8.0.crate",
+        "sha256": "a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8",
+        "dest": "cargo/vendor",
+        "dest-filename": "md-5-0.8.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/md-5-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/memchr/memchr-2.2.1.crate",
+        "sha256": "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e",
+        "dest": "cargo/vendor",
+        "dest-filename": "memchr-2.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2288579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/memchr-2.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/memoffset/memoffset-0.5.3.crate",
+        "sha256": "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9",
+        "dest": "cargo/vendor",
+        "dest-filename": "memoffset-0.5.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2275189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/memoffset-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/mio/mio-0.6.21.crate",
+        "sha256": "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f",
+        "dest": "cargo/vendor",
+        "dest-filename": "mio-0.6.21.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/mio-0.6.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/mio-uds/mio-uds-0.6.7.crate",
+        "sha256": "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125",
+        "dest": "cargo/vendor",
+        "dest-filename": "mio-uds-0.6.7.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/mio-uds-0.6.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/miow/miow-0.2.1.crate",
+        "sha256": "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919",
+        "dest": "cargo/vendor",
+        "dest-filename": "miow-0.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/miow-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/mnt/mnt-0.3.1.crate",
+        "sha256": "1587ebb20a5b04738f16cffa7e2526f1b8496b84f92920facd518362ff1559eb",
+        "dest": "cargo/vendor",
+        "dest-filename": "mnt-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221587ebb20a5b04738f16cffa7e2526f1b8496b84f92920facd518362ff1559eb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/mnt-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/net2/net2-0.2.33.crate",
+        "sha256": "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88",
+        "dest": "cargo/vendor",
+        "dest-filename": "net2-0.2.33.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2242550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/net2-0.2.33",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/nom/nom-5.1.2.crate",
+        "sha256": "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af",
+        "dest": "cargo/vendor",
+        "dest-filename": "nom-5.1.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/nom-5.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/num_cpus/num_cpus-1.11.1.crate",
+        "sha256": "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72",
+        "dest": "cargo/vendor",
+        "dest-filename": "num_cpus-1.11.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2276dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/num_cpus-1.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/num_enum/num_enum-0.5.1.crate",
+        "sha256": "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066",
+        "dest": "cargo/vendor",
+        "dest-filename": "num_enum-0.5.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/num_enum-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.5.1.crate",
+        "sha256": "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e",
+        "dest": "cargo/vendor",
+        "dest-filename": "num_enum_derive-0.5.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/num_enum_derive-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/numtoa/numtoa-0.1.0.crate",
+        "sha256": "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef",
+        "dest": "cargo/vendor",
+        "dest-filename": "numtoa-0.1.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/numtoa-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.2.0.crate",
+        "sha256": "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed",
+        "dest": "cargo/vendor",
+        "dest-filename": "once_cell-1.2.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/once_cell-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/opaque-debug/opaque-debug-0.2.3.crate",
+        "sha256": "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c",
+        "dest": "cargo/vendor",
+        "dest-filename": "opaque-debug-0.2.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/opaque-debug-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pango/pango-0.9.0.crate",
+        "sha256": "460dbe5ad850c46780ba61f142e966beacf5eebb09822830f796c91d7d4fec31",
+        "dest": "cargo/vendor",
+        "dest-filename": "pango-0.9.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22460dbe5ad850c46780ba61f142e966beacf5eebb09822830f796c91d7d4fec31%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pango-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.10.0.crate",
+        "sha256": "24d2650c8b62d116c020abd0cea26a4ed96526afda89b1c4ea567131fdefc890",
+        "dest": "cargo/vendor",
+        "dest-filename": "pango-sys-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2224d2650c8b62d116c020abd0cea26a4ed96526afda89b1c4ea567131fdefc890%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pango-sys-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.10.0.crate",
+        "sha256": "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc",
+        "dest": "cargo/vendor",
+        "dest-filename": "parking_lot-0.10.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2292e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/parking_lot-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.7.0.crate",
+        "sha256": "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1",
+        "dest": "cargo/vendor",
+        "dest-filename": "parking_lot_core-0.7.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/parking_lot_core-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pbr/pbr-1.0.2.crate",
+        "sha256": "4403eb718d70c03ee279e51737782902c68cca01e870a33b6a2f9dfb50b9cd83",
+        "dest": "cargo/vendor",
+        "dest-filename": "pbr-1.0.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224403eb718d70c03ee279e51737782902c68cca01e870a33b6a2f9dfb50b9cd83%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pbr-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pin-project/pin-project-0.4.6.crate",
+        "sha256": "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469",
+        "dest": "cargo/vendor",
+        "dest-filename": "pin-project-0.4.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2294b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pin-project-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-0.4.6.crate",
+        "sha256": "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355",
+        "dest": "cargo/vendor",
+        "dest-filename": "pin-project-internal-0.4.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2244ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pin-project-internal-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.1.1.crate",
+        "sha256": "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991",
+        "dest": "cargo/vendor",
+        "dest-filename": "pin-project-lite-0.1.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pin-project-lite-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pin-utils/pin-utils-0.1.0-alpha.4.crate",
+        "sha256": "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587",
+        "dest": "cargo/vendor",
+        "dest-filename": "pin-utils-0.1.0-alpha.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pin-utils-0.1.0-alpha.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.17.crate",
+        "sha256": "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677",
+        "dest": "cargo/vendor",
+        "dest-filename": "pkg-config-0.3.17.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2205da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pkg-config-0.3.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-0.1.5.crate",
+        "sha256": "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785",
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro-crate-0.1.5.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/proc-macro-crate-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.3.crate",
+        "sha256": "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880",
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro-error-1.0.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/proc-macro-error-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-1.0.3.crate",
+        "sha256": "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50",
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro-error-attr-1.0.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/proc-macro-hack/proc-macro-hack-0.5.11.crate",
+        "sha256": "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5",
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro-hack-0.5.11.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/proc-macro-hack-0.5.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/proc-macro-nested/proc-macro-nested-0.1.3.crate",
+        "sha256": "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e",
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro-nested-0.1.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/proc-macro-nested-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.6.crate",
+        "sha256": "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27",
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro2-1.0.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/proc-macro2-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/pwd/pwd-1.3.0.crate",
+        "sha256": "5dd32d8bece608e144ca20251e714ed107cdecdabb20c2d383cfc687825106a5",
+        "dest": "cargo/vendor",
+        "dest-filename": "pwd-1.3.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225dd32d8bece608e144ca20251e714ed107cdecdabb20c2d383cfc687825106a5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/pwd-1.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/quote/quote-1.0.2.crate",
+        "sha256": "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe",
+        "dest": "cargo/vendor",
+        "dest-filename": "quote-1.0.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/quote-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.1.56.crate",
+        "sha256": "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84",
+        "dest": "cargo/vendor",
+        "dest-filename": "redox_syscall-0.1.56.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/redox_syscall-0.1.56",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/redox_termios/redox_termios-0.1.1.crate",
+        "sha256": "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76",
+        "dest": "cargo/vendor",
+        "dest-filename": "redox_termios-0.1.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/redox_termios-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/regex/regex-1.3.1.crate",
+        "sha256": "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd",
+        "dest": "cargo/vendor",
+        "dest-filename": "regex-1.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/regex-1.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.6.12.crate",
+        "sha256": "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716",
+        "dest": "cargo/vendor",
+        "dest-filename": "regex-syntax-0.6.12.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2211a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/regex-syntax-0.6.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/ron/ron-0.5.1.crate",
+        "sha256": "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5",
+        "dest": "cargo/vendor",
+        "dest-filename": "ron-0.5.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/ron-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/rustc-demangle/rustc-demangle-0.1.16.crate",
+        "sha256": "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783",
+        "dest": "cargo/vendor",
+        "dest-filename": "rustc-demangle-0.1.16.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/rustc-demangle-0.1.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.2.3.crate",
+        "sha256": "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
+        "dest": "cargo/vendor",
+        "dest-filename": "rustc_version-0.2.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/rustc_version-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/ryu/ryu-1.0.5.crate",
+        "sha256": "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e",
+        "dest": "cargo/vendor",
+        "dest-filename": "ryu-1.0.5.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2271d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/ryu-1.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.0.0.crate",
+        "sha256": "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d",
+        "dest": "cargo/vendor",
+        "dest-filename": "scopeguard-1.0.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/scopeguard-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/semver/semver-0.9.0.crate",
+        "sha256": "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403",
+        "dest": "cargo/vendor",
+        "dest-filename": "semver-0.9.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/semver-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/semver-parser/semver-parser-0.7.0.crate",
+        "sha256": "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3",
+        "dest": "cargo/vendor",
+        "dest-filename": "semver-parser-0.7.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/semver-parser-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/serde/serde-1.0.104.crate",
+        "sha256": "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449",
+        "dest": "cargo/vendor",
+        "dest-filename": "serde-1.0.104.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/serde-1.0.104",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.104.crate",
+        "sha256": "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64",
+        "dest": "cargo/vendor",
+        "dest-filename": "serde_derive-1.0.104.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/serde_derive-1.0.104",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/sha2/sha2-0.8.0.crate",
+        "sha256": "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d",
+        "dest": "cargo/vendor",
+        "dest-filename": "sha2-0.8.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/sha2-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/slab/slab-0.4.2.crate",
+        "sha256": "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8",
+        "dest": "cargo/vendor",
+        "dest-filename": "slab-0.4.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/slab-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.0.0.crate",
+        "sha256": "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86",
+        "dest": "cargo/vendor",
+        "dest-filename": "smallvec-1.0.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/smallvec-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/srmw/srmw-0.1.1.crate",
+        "sha256": "f554d8c36d9555945af2065c967bce4e307484f436045ab7d6463075cb757ac2",
+        "dest": "cargo/vendor",
+        "dest-filename": "srmw-0.1.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f554d8c36d9555945af2065c967bce4e307484f436045ab7d6463075cb757ac2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/srmw-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate",
+        "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
+        "dest": "cargo/vendor",
+        "dest-filename": "static_assertions-1.1.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/static_assertions-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/strsim/strsim-0.8.0.crate",
+        "sha256": "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a",
+        "dest": "cargo/vendor",
+        "dest-filename": "strsim-0.8.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/strsim-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/strum/strum-0.18.0.crate",
+        "sha256": "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b",
+        "dest": "cargo/vendor",
+        "dest-filename": "strum-0.18.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2257bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/strum-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/strum_macros/strum_macros-0.18.0.crate",
+        "sha256": "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c",
+        "dest": "cargo/vendor",
+        "dest-filename": "strum_macros-0.18.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2287c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/strum_macros-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/syn/syn-1.0.11.crate",
+        "sha256": "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238",
+        "dest": "cargo/vendor",
+        "dest-filename": "syn-1.0.11.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/syn-1.0.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/syn-mid/syn-mid-0.5.0.crate",
+        "sha256": "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a",
+        "dest": "cargo/vendor",
+        "dest-filename": "syn-mid-0.5.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/syn-mid-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/synstructure/synstructure-0.12.3.crate",
+        "sha256": "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545",
+        "dest": "cargo/vendor",
+        "dest-filename": "synstructure-0.12.3.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2267656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/synstructure-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/sys-mount/sys-mount-1.2.1.crate",
+        "sha256": "62f5703caf67c45ad3450104001b4620a605e9def0cef13dde3c9add23f73cee",
+        "dest": "cargo/vendor",
+        "dest-filename": "sys-mount-1.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2262f5703caf67c45ad3450104001b4620a605e9def0cef13dde3c9add23f73cee%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/sys-mount-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/system-deps/system-deps-1.3.2.crate",
+        "sha256": "0f3ecc17269a19353b3558b313bba738b25d82993e30d62a18406a24aba4649b",
+        "dest": "cargo/vendor",
+        "dest-filename": "system-deps-1.3.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220f3ecc17269a19353b3558b313bba738b25d82993e30d62a18406a24aba4649b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/system-deps-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/termion/termion-1.5.4.crate",
+        "sha256": "818ef3700c2a7b447dca1a1dd28341fe635e6ee103c806c636bb9c929991b2cd",
+        "dest": "cargo/vendor",
+        "dest-filename": "termion-1.5.4.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22818ef3700c2a7b447dca1a1dd28341fe635e6ee103c806c636bb9c929991b2cd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/termion-1.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/termios/termios-0.3.1.crate",
+        "sha256": "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625",
+        "dest": "cargo/vendor",
+        "dest-filename": "termios-0.3.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2272b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/termios-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/textwrap/textwrap-0.11.0.crate",
+        "sha256": "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060",
+        "dest": "cargo/vendor",
+        "dest-filename": "textwrap-0.11.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/textwrap-0.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.20.crate",
+        "sha256": "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08",
+        "dest": "cargo/vendor",
+        "dest-filename": "thiserror-1.0.20.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/thiserror-1.0.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.20.crate",
+        "sha256": "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793",
+        "dest": "cargo/vendor",
+        "dest-filename": "thiserror-impl-1.0.20.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/thiserror-impl-1.0.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/time/time-0.1.42.crate",
+        "sha256": "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f",
+        "dest": "cargo/vendor",
+        "dest-filename": "time-0.1.42.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/time-0.1.42",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/toml/toml-0.5.6.crate",
+        "sha256": "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a",
+        "dest": "cargo/vendor",
+        "dest-filename": "toml-0.5.6.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/toml-0.5.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/typenum/typenum-1.11.2.crate",
+        "sha256": "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9",
+        "dest": "cargo/vendor",
+        "dest-filename": "typenum-1.11.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/typenum-1.11.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.6.0.crate",
+        "sha256": "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0",
+        "dest": "cargo/vendor",
+        "dest-filename": "unicode-segmentation-1.6.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/unicode-segmentation-1.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.7.crate",
+        "sha256": "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479",
+        "dest": "cargo/vendor",
+        "dest-filename": "unicode-width-0.1.7.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/unicode-width-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.0.crate",
+        "sha256": "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c",
+        "dest": "cargo/vendor",
+        "dest-filename": "unicode-xid-0.2.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/unicode-xid-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/usb-disk-probe/usb-disk-probe-0.1.0.crate",
+        "sha256": "0904fa5b9f719cc95b2c901186f083abab810daaafc8d200f9628c04d9cd29e2",
+        "dest": "cargo/vendor",
+        "dest-filename": "usb-disk-probe-0.1.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220904fa5b9f719cc95b2c901186f083abab810daaafc8d200f9628c04d9cd29e2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/usb-disk-probe-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/vec_map/vec_map-0.8.1.crate",
+        "sha256": "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a",
+        "dest": "cargo/vendor",
+        "dest-filename": "vec_map-0.8.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2205c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/vec_map-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/version-compare/version-compare-0.0.10.crate",
+        "sha256": "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1",
+        "dest": "cargo/vendor",
+        "dest-filename": "version-compare-0.0.10.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/version-compare-0.0.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/version_check/version_check-0.9.2.crate",
+        "sha256": "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed",
+        "dest": "cargo/vendor",
+        "dest-filename": "version_check-0.9.2.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/version_check-0.9.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/winapi/winapi-0.2.8.crate",
+        "sha256": "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a",
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-0.2.8.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/winapi-0.2.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/winapi/winapi-0.3.8.crate",
+        "sha256": "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6",
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-0.3.8.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/winapi-0.3.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/winapi-build/winapi-build-0.1.1.crate",
+        "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-build-0.1.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/winapi-build-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-i686-pc-windows-gnu-0.4.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-x86_64-pc-windows-gnu-0.4.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/ws2_32-sys/ws2_32-sys-0.2.1.crate",
+        "sha256": "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e",
+        "dest": "cargo/vendor",
+        "dest-filename": "ws2_32-sys-0.2.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/ws2_32-sys-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "shell",
+        "dest": "cargo/vendor",
+        "commands": [
+            "for c in *.crate; do tar -xf $c; done"
+        ]
+    },
+    {
+        "type": "file",
+        "url": "data:%5Bsource.vendored-sources%5D%0Adirectory%20%3D%20%22cargo/vendor%22%0A%0A%5Bsource.crates-io%5D%0Areplace-with%20%3D%20%22vendored-sources%22%0A%0A%5Bsource.%22https%3A//github.com/pop-os/dbus-udisks2%22%5D%0Agit%20%3D%20%22https%3A//github.com/pop-os/dbus-udisks2%22%0Areplace-with%20%3D%20%22vendored-sources%22%0Abranch%20%3D%20%22master%22%0A%0A%5Bsource.%22https%3A//github.com/ids1024/iso9660-rs%22%5D%0Agit%20%3D%20%22https%3A//github.com/ids1024/iso9660-rs%22%0Areplace-with%20%3D%20%22vendored-sources%22%0Abranch%20%3D%20%22master%22%0A",
+        "dest": "cargo",
+        "dest-filename": "config"
+    }
+]


### PR DESCRIPTION
This adds a GitHub Actions workflow to test the Flatpak build; this can ensure future changes don't break the Flatpak build. Requires a Flatpak manifest, e.g. from #187