### PR TITLE
Fix broken command-line tool

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -124,7 +124,7 @@ async fn popsicle(
         popsicle::usb_disk_devices(&mut disk_args)
             .await
             .with_context(|| fl!("error-disks-fetch"))?;
-    } else if let Some(disks) = matches.get_many::<String>("DISKS") {
+    } else if let Some(disks) = matches.get_many::<String>(&fl!("arg-disks")) {
         disk_args.extend(disks.map(PathBuf::from).map(Box::from));
     }
 
@@ -155,7 +155,7 @@ async fn popsicle(
         let mut confirm = String::new();
         io::stdin().read_line(&mut confirm).unwrap();
 
-        if confirm.trim() != "y" && confirm.trim() != "yes" {
+        if confirm.trim() != &fl!("y") && confirm.trim() != "yes" {
             return Err(anyhow!(fl!("error-exiting")));
         }
     }

--- a/i18n/bn/popsicle_cli.ftl
+++ b/i18n/bn/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = তুমি কি আসলেই '{$image_path}' এই ড্রাইভে ইন্সটল করতে চাও?
 
 yn = y/N 
+y = y
 
 # Arguments
 arg-image = ইমেজ

--- a/i18n/ca/popsicle_cli.ftl
+++ b/i18n/ca/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Segur que vols escriure '{$image_path}' als dispositius següents?
 
 yn = s/N
+y = s
 
 # Arguments
 arg-image = IMATGE

--- a/i18n/cs/popsicle_cli.ftl
+++ b/i18n/cs/popsicle_cli.ftl
@@ -1,5 +1,6 @@
 question = Jste si jistí, že chcete flashnout '{$image_path}' do následujících disků?
 yn = y/N
+y = y
 
 # Arguments
 arg-image = OBRAZ

--- a/i18n/de/popsicle_cli.ftl
+++ b/i18n/de/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Sind sie sicher, dass sie '{$image_path}' auf folgende Datenträger schreiben möchten?
 
 yn = J/N
+y = j
 
 # Arguments
 arg-image = ABBILD

--- a/i18n/en/popsicle_cli.ftl
+++ b/i18n/en/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Are you sure you want to flash '{$image_path}' to the following drives?
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = IMAGE

--- a/i18n/fi/popsicle_cli.ftl
+++ b/i18n/fi/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Oletko varma, että haluat kirjoittaa '{$image_path}' tähän asemaan?
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = LEVYKUVA

--- a/i18n/hu/popsicle_cli.ftl
+++ b/i18n/hu/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Ki szeretnéd írni a '{$image_path}' a következő eszközökre?
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = LEMEZKÉP

--- a/i18n/it/popsicle_cli.ftl
+++ b/i18n/it/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Sei sicuro di voler caricare '{$image_path}' nelle seguenti unità USB?
 
 yn = s/N
+y = s
 
 # Arguments
 arg-image = IMMAGINE

--- a/i18n/ja/popsicle_cli.ftl
+++ b/i18n/ja/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = 次のデバイスに'{$image_path}'を書き込むで間違いありませんか?
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = イメージ

--- a/i18n/ko/popsicle_cli.ftl
+++ b/i18n/ko/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = 선택한 기기에 '{$image_path}'를 플레시 하시겠습니까?
 
 yn = 예/아니오(y/N)
+y = 예
 
 # Arguments
 arg-image = 이미지

--- a/i18n/pt-BR/popsicle_cli.ftl
+++ b/i18n/pt-BR/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Você tem certeza de que quer gravar '{$image_path}' nos seguintes dispositivos?
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = IMAGEM

--- a/i18n/pt/popsicle_cli.ftl
+++ b/i18n/pt/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Gravar '{$image_path}' nos seguintes dispositivos?
 
 yn = s/N
+y = s
 
 # Arguments
 arg-image = IMAGEM

--- a/i18n/ru/popsicle_cli.ftl
+++ b/i18n/ru/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Вы уверены, что хотите записать '{$image_path}' на следующие диски?
 
 yn = y/n
+y = y
 
 # Arguments
 arg-image = ОБРАЗ

--- a/i18n/sl/popsicle_cli.ftl
+++ b/i18n/sl/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Ali ste prepričani, da želite '{$image_path}' utripati na naslednje pogone?
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = SLIKA

--- a/i18n/sr/popsicle_cli.ftl
+++ b/i18n/sr/popsicle_cli.ftl
@@ -1,7 +1,8 @@
 question = Da li ste sigurni da želite da pomoću '{$image_path}' napravite sledeće uređaje instalacionim uređajima?
 
 yn = d/N
-
+y = d
+ 
 # Arguments
 arg-image = FAJL
 arg-image-desc = Ulazni instalacioni fajl

--- a/i18n/sv/popsicle_cli.ftl
+++ b/i18n/sv/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = Är du säker på att du vill bränna '{$image_path}' till dessa diskar?
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = OS Fil

--- a/i18n/tr/popsicle_cli.ftl
+++ b/i18n/tr/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = '{$image_path}' konumundaki disk görüntüsünü listelenen bellek aygıtlarına yazdırmak istediğinize emin misiniz?
 
 yn = e/H
+y = e
 
 # Arguments
 arg-image = DİSK GÖRÜNTÜSÜ

--- a/i18n/zh-CN/popsicle_cli.ftl
+++ b/i18n/zh-CN/popsicle_cli.ftl
@@ -1,6 +1,7 @@
 question = 你确实要将 '{$image_path}' 镜像刷入到所示的磁盘吗？
 
 yn = y/N
+y = y
 
 # Arguments
 arg-image = 镜像


### PR DESCRIPTION
The command line interface of popsicle seems to be broken, this PR fixes  the following issues:
* due to inconsistencies in naming the target device parameter, no target device other than "all" could be specified
* The question asking whether or not to write the image to the target was local language specific, but only english answers have been accpeted.