### PR TITLE
Use patched `pbr` to fix cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,8 +1554,7 @@ dependencies = [
 [[package]]
 name = "pbr"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5827dfa0d69b6c92493d6c38e633bbaa5937c153d0d7c28bf12313f8c6d514"
+source = "git+https://github.com/ids1024/pb?branch=write#225bf70cdaf86193c4a6e65079ebccc1b2196c57"
 dependencies = [
  "crossbeam-channel",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ i18n-embed = { version = "0.13.4", features = ["fluent-system", "desktop-request
 i18n-embed-fl = "0.6.4"
 libc = "0.2.134"
 once_cell = "1.15.0"
-pbr = "1.0.4"
+# pbr = "1.0.4"
+pbr = { git = "https://github.com/ids1024/pb", branch = "write" }
 popsicle = { path = ".." }
 rust-embed = { version = "6.4.1", features = ["debug-embed"] }


### PR DESCRIPTION
Fixes https://github.com/pop-os/popsicle/issues/201.

This should be changed when https://github.com/a8m/pb/pull/120 is merged and released.