### PR TITLE
fix: update loopdev to loopdev-erikh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d90cd0b264dfdd8eb5bad0a2c217c1f88fa96a8573f40e7b12de23fb468f46"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "atk"
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
  "bitflags 1.3.2",
  "cexpr",
@@ -340,6 +340,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -490,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.12"
+version = "4.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
+checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
 dependencies = [
  "clap_builder",
 ]
@@ -544,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -630,7 +631,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -651,7 +652,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -892,7 +893,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1273,7 +1274,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.46",
+ "syn 2.0.48",
  "unic-langid",
 ]
 
@@ -1287,7 +1288,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1449,10 +1450,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "loopdev"
-version = "0.4.0"
+name = "loopdev-erikh"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfa0855b04611e38acaff718542e9e809cddfc16535d39f9d9c694ab19f7388"
+checksum = "ac18afc683a3326b4ba3a7c783ae6613095c8ce49e0d7bce41a2bd58da319b8d"
 dependencies = [
  "bindgen",
  "errno 0.2.8",
@@ -1862,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
@@ -1958,7 +1959,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.46",
+ "syn 2.0.48",
  "walkdir",
 ]
 
@@ -2073,7 +2074,7 @@ checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2140,13 +2141,13 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smart-default"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2191,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2202,13 +2203,13 @@ dependencies = [
 
 [[package]]
 name = "sys-mount"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6b8b397ed1fa2364625189a004d532b5d58f772943c57aa144feb1966142bd"
+checksum = "65a290d26aaf4d91fc55cf2afde5079c14e5e4ebffebe8f847234b0dc0df8742"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
- "loopdev",
+ "loopdev-erikh",
  "smart-default",
  "thiserror",
  "tracing",
@@ -2250,7 +2251,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2363,7 +2364,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2434,9 +2435,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "value-bag"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+checksum = "62ce5bb364b23e66b528d03168df78b38c0f7b6fe17386928f29d5ab2e7cb2f7"
 
 [[package]]
 name = "version-compare"
@@ -2487,7 +2488,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2521,7 +2522,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2773,9 +2774,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.31"
+version = "0.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a4882e6b134d6c28953a387571f1acdd3496830d5e36c5e3a1075580ea641c"
+checksum = "8434aeec7b290e8da5c3f0d628cb0eac6cabcb31d14bb74f779a08109a5914d6"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,18 @@ path = "src/lib.rs"
 members = ["cli", "gtk"]
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.79"
 as-result = "0.2.1"
 async-std = "1.12.0"
 derive-new = "0.6.0"
-futures = "0.3.24"
+futures = "0.3.30"
 futures_codec = "0.4.1"
-libc = "0.2.134"
-memchr = "2.5.0"
+libc = "0.2.151"
+memchr = "2.7.1"
 mnt = "0.3.1"
-ron = "0.8.0"
-serde = { version = "1.0.145", features = ["derive"] }
+ron = "0.8.1"
+serde = { version = "1.0.194", features = ["derive"] }
 srmw = "0.1.1"
-thiserror = "1.0.37"
+thiserror = "1.0.56"
 usb-disk-probe = "0.2.0"
+

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,19 +12,19 @@ name = "popsicle"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.79"
 async-std = "1.12.0"
 atty = "0.2.14"
 better-panic = "0.3.0"
 cascade = "1.0.1"
-clap = "4.0.8"
+clap = "4.4.13"
 derive-new = "0.6.0"
-fomat-macros = "0.3.1"
-futures = "0.3.24"
+fomat-macros = "0.3.2"
+futures = "0.3.30"
 i18n-embed = { version = "0.14.1", features = ["fluent-system", "desktop-requester"] }
 i18n-embed-fl = "0.7.0"
-libc = "0.2.134"
-once_cell = "1.15.0"
+libc = "0.2.151"
+once_cell = "1.19.0"
 # pbr = "1.0.4"
 pbr = { git = "https://github.com/ids1024/pb", branch = "write" }
 popsicle = { path = ".." }

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -13,32 +13,32 @@ path = "src/main.rs"
 
 [dependencies]
 atomic = "0.6.0"
-anyhow = "1.0.65"
+anyhow = "1.0.79"
 bytemuck = "1.14.0"
-bytesize = "1.1.0"
+bytesize = "1.3.0"
 cascade = "1.0.1"
-crossbeam-channel = "0.5.6"
-dbus = "0.9.6"
+crossbeam-channel = "0.5.10"
+dbus = "0.9.7"
 dbus-udisks2 = { git = "https://github.com/pop-os/dbus-udisks2" }
-digest = "0.10.5"
-futures = "0.3.24"
-gdk = "0.17.0"
-gdk-pixbuf = "0.17.0"
-gio = "0.17.0"
-glib = "0.17.0"
-gtk = { version = "0.17.0" }
+digest = "0.10.7"
+futures = "0.3.30"
+gdk = "0.17.1"
+gdk-pixbuf = "0.17.10"
+gio = "0.17.10"
+glib = "0.17.10"
+gtk = { version = "0.17.1" }
 hex-view = "0.1.3"
 iso9660 = { git = "https://github.com/ids1024/iso9660-rs" }
-libc = "0.2.134"
-md-5 = "0.10.5"
-pango = "0.17.0"
+libc = "0.2.151"
+md-5 = "0.10.6"
+pango = "0.17.10"
 popsicle = { path = ".." }
 pwd = "1.4.0"
-sha2 = "0.10.6"
-sha-1 = { version = "0.10.0", features = ["asm"] }
-sys-mount = "2.0.2"
+sha2 = "0.10.8"
+sha-1 = { version = "0.10.1", features = ["asm"] }
+sys-mount = "2.1.1"
 async-std = "1.12.0"
 i18n-embed = { version = "0.14.1", features = ["fluent-system", "desktop-requester"] }
 i18n-embed-fl = "0.7.0"
 rust-embed = { version = "8.2.0", features = ["debug-embed"] }
-once_cell = "1.15.0"
+once_cell = "1.19.0"


### PR DESCRIPTION
This will bump bindgen to version 63.0, which should fix #208, where bindgen has build errors on newer versions of Clang. Loopdev has been abandoned (https://github.com/rustsec/advisory-db/issues/1821), but `loopdev-erikh` is maintained.