### PR TITLE
add sha512

### DIFF
--- a/gtk/src/app/events/mod.rs
+++ b/gtk/src/app/events/mod.rs
@@ -6,6 +6,7 @@ use dbus_udisks2::{DiskDevice, Disks, UDisks2};
 use md5::Md5;
 use sha1::Sha1;
 use sha2::Sha256;
+use sha2::Sha512;
 use std::collections::HashMap;
 use std::io;
 use std::path::PathBuf;
@@ -46,6 +47,7 @@ pub fn background_thread(events_tx: Sender<UiEvent>, events_rx: Receiver<Backgro
                         "MD5" => hasher::<Md5>(&path),
                         "SHA256" => hasher::<Sha256>(&path),
                         "SHA1" => hasher::<Sha1>(&path),
+                        "SHA512" => hasher::<Sha512>(&path),
                         _ => Err(io::Error::new(
                             io::ErrorKind::InvalidInput,
                             "hash kind not supported",

--- a/gtk/src/app/signals/images.rs
+++ b/gtk/src/app/signals/images.rs
@@ -52,9 +52,10 @@ fn set_hash_widget(state: &State, ui: &GtkUi) {
 
     let path = state.image_path.borrow();
     let kind = match hash.active() {
-        Some(1) => "SHA256",
-        Some(2) => "SHA1",
-        Some(3) => "MD5",
+        Some(1) => "SHA512",
+        Some(2) => "SHA256",
+        Some(3) => "SHA1",
+        Some(4) => "MD5",
         _ => return,
     };
 

--- a/gtk/src/app/views/images.rs
+++ b/gtk/src/app/views/images.rs
@@ -56,6 +56,7 @@ impl ImageView {
         let hash = cascade! {
             ComboBoxText::new();
             ..append_text(&fl!("none"));
+            ..append_text("SHA512");
             ..append_text("SHA256");
             ..append_text("SHA1");
             ..append_text("MD5");


### PR DESCRIPTION
Adds sha512 to the hashing options as I noticed some distributions use as their only verification hash such as EndevourOS.  